### PR TITLE
Fixed issue with Mono. Mono throws exception when null is assigned to Pr...

### DIFF
--- a/src/XmlTransformer/XmlElementContext.cs
+++ b/src/XmlTransformer/XmlElementContext.cs
@@ -230,7 +230,7 @@ namespace XmlTransformer
                     else if (xmlAttribute.Prefix.Equals("xmlns") || xmlAttribute.Name.Equals("xmlns"))
                         list.Add(xmlAttribute);
                     else
-                        xmlAttribute.Prefix = (string)null;
+                        xmlAttribute.Prefix = string.Empty;
                 }
                 foreach (XmlAttribute node1 in list)
                     node.Attributes.Remove(node1);


### PR DESCRIPTION
Fixed issue with Mono. Mono throws exception when null is assigned to Prefix.

Argument cannot be null.
Parameter name: key
XmlTransformer.XmlNodeException: Argument cannot be null.
Parameter name: key ---> System.ArgumentNullException: Argument cannot be null.
Parameter name: key
  at System.Xml.NameTable.Add (System.String key) [0x00000] in <filename unknown>:0
  at System.Xml.XmlAttribute.set_Prefix (System.String value) [0x00000] in <filename unknown>:0
  at XmlTransformer.XmlElementContext.ScrubTransformAttributesAndNamespaces (System.Xml.XmlNode node) [0x00000] in <filename unknown>:0
  at XmlTransformer.XmlElementContext.CreateCloneInTargetDocument (System.Xml.XmlNode sourceNode) [0x00000] in <filename unknown>:0
  at XmlTransformer.XmlElementContext.get_TransformNode () [0x00000] in <filename unknown>:0
  at XmlTransformer.Transform.get_TransformNode () [0x00000] in <filename unknown>:0
  at XmlTransformer.Replace.Apply () [0x00000] in <filename unknown>:0
  at XmlTransformer.Transform.ApplyOnce () [0x00000] in <filename unknown>:0
  at XmlTransformer.Transform.Execute (XmlTransformer.XmlElementContext context, System.String argumentString) [0x00000] in <filename unknown>:0
  --- End of inner exception stack trace ---
  Error during Replace
  Executing Replace (transform line 10, 40)
